### PR TITLE
Update to Minecraft Java 26.3 snapshot 4 and above (26.3+)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.jvmargs = -Xmx1G
 	loader_version=0.19.2
 
 # Mod Properties
-	mod_version = 1.1.0
+	mod_version = 1.2.0
 	maven_group = juliand665
 	archives_base_name = retino
 

--- a/src/main/java/retino/mixin/GlBackendMixin.java
+++ b/src/main/java/retino/mixin/GlBackendMixin.java
@@ -1,19 +1,16 @@
 package retino.mixin;
 
-import com.mojang.blaze3d.opengl.GlBackend;
-import org.lwjgl.glfw.GLFW;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
-@Mixin(value = GlBackend.class)
+@Mixin(targets = "com.mojang.blaze3d.platform.Window")
 public abstract class GlBackendMixin {
-	@Inject(
-		at = @At("HEAD"),
-		method = "setWindowHints"
+	@ModifyConstant(
+		method = "createWindow",
+		constant = @Constant(longValue = 8192L)
 	)
-	private void adjustWindowHints(CallbackInfo callbackInfo) {
-		GLFW.glfwWindowHint(GLFW.GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW.GLFW_FALSE);
+	private long disableHighPixelDensity(long constant) {
+		return 0L;
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,7 +25,7 @@
 
 	"depends": {
 		"fabricloader": ">=0.4.0",
-		"minecraft": ">=26.1"
+		"minecraft": ">=26.3-alpha.4"
 	},
 	
 	"custom": {


### PR DESCRIPTION
Tested on 26.3 Snapshot 4 and 26.3 Snapshot 8 (latest snapshot as of 8/16/26)
I also bumped the version to 1.2.0 as that made sense

<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/59b8b853-8ada-4711-a352-76c2c2ff0a1f" />

Build available @ https://github.com/mrtacoguy01/retiNO/releases/tag/1.2.0

System Info:
Apple M1 MacBook Air

Built with:
Java 25
IBM Semeru Runtime Open Edition
25.0.4.0
OpenJDK 25.0.4+7
OpenJ9 0.60.0
macOS aarch64