### PR TITLE
Update to 26.3 / SDL3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.jvmargs = -Xmx1G
 	loader_version=0.19.2
 
 # Mod Properties
-	mod_version = 1.2.0
+	mod_version = 1.2.1
 	maven_group = juliand665
 	archives_base_name = retino
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.jvmargs = -Xmx1G
 	loader_version=0.19.2
 
 # Mod Properties
-	mod_version = 1.1.0
+	mod_version = 1.2.0
 	maven_group = juliand665
 	archives_base_name = retino
 

--- a/src/main/java/retino/mixin/GlBackendMixin.java
+++ b/src/main/java/retino/mixin/GlBackendMixin.java
@@ -1,19 +1,16 @@
 package retino.mixin;
 
-import com.mojang.blaze3d.opengl.GlBackend;
-import org.lwjgl.glfw.GLFW;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
-@Mixin(value = GlBackend.class)
+@Mixin(targets = "com.mojang.blaze3d.platform.Window")
 public abstract class GlBackendMixin {
-	@Inject(
-		at = @At("HEAD"),
-		method = "setWindowHints"
+	@ModifyConstant(
+		method = "createWindow",
+		constant = @Constant(longValue = 8192L)
 	)
-	private void adjustWindowHints(CallbackInfo callbackInfo) {
-		GLFW.glfwWindowHint(GLFW.GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW.GLFW_FALSE);
+	private long disableHighPixelDensity(long constant) {
+		return 0L;
 	}
 }

--- a/src/main/java/retino/mixin/GlBackendMixin.java
+++ b/src/main/java/retino/mixin/GlBackendMixin.java
@@ -1,16 +1,28 @@
 package retino.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.Constant;
-import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 @Mixin(targets = "com.mojang.blaze3d.platform.Window")
 public abstract class GlBackendMixin {
-	@ModifyConstant(
+	@ModifyArg(
 		method = "createWindow",
-		constant = @Constant(longValue = 8192L)
+		at = @At(
+			value = "INVOKE",
+			target = "Lcom/mojang/renderpearl/api/device/GpuBackend;createWindow(Ljava/lang/String;IIJ)J"
+		),
+		index = 3
 	)
-	private long disableHighPixelDensity(long constant) {
-		return 0L;
+	private long disableHighPixelDensity(long flags) {
+		try {
+			Class<?> sdlVideo = Class.forName("org.lwjgl.sdl.SDLVideo");
+			long highPixelDensity =
+				sdlVideo.getField("SDL_WINDOW_HIGH_PIXEL_DENSITY").getLong(null);
+
+			return flags & ~highPixelDensity;
+		} catch (ReflectiveOperationException e) {
+			return flags;
+		}
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,7 +25,7 @@
 
 	"depends": {
 		"fabricloader": ">=0.4.0",
-		"minecraft": ">=26.1"
+		"minecraft": ">=26.3-alpha.4"
 	},
 	
 	"custom": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,7 +25,7 @@
 
 	"depends": {
 		"fabricloader": ">=0.4.0",
-		"minecraft": ">=26.3-alpha.4"
+		"minecraft": ">=26.3-alpha.9"
 	},
 	
 	"custom": {


### PR DESCRIPTION
sorry for the 3rd pr now, im still learning how to use git and i keep messing things up

Updated to 26.3 snapshot 9 and above (it should work until release but im not 100% sure as things can change at any time)

Since Minecraft 26.3 snapshot 4, Minecraft has switched from GLFW to SDL3 so GLFW_COCOA_RETINA_FRAMEBUFFER no longer exists, in this case SDL_WINDOW_HIGH_PIXEL_DENSITY replaces GLFW_COCOA_RETINA_FRAMEBUFFER

the reflective lookup is the best option I could come up with to avoid hard coding values so the mod doesnt break when changes are made to SDL or LWJGL in the future (they could still break if there are major changes)

i also bumped to 1.2.1 since my last pr
1.2.0 was to add 26.3 support
and 1.2.1 was this patch for snapshot 9
you can change this yourself if you dont like it or keep it

Build available @ https://github.com/mrtacoguy01/retiNO/releases/tag/1.2.1

<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/8d20787b-2232-4bfa-875e-e408707db1f7" />

Tested and working on OpenGL and Vulkan

System Info:
Apple M1 MacBook Air

Built with:
Java 25
IBM Semeru Runtime Open Edition
25.0.4.0
OpenJDK 25.0.4+7
OpenJ9 0.60.0
macOS aarch64
Downloaded from: https://developer.ibm.com/languages/java/semeru-runtimes/downloads/
Direct Download: https://github.com/ibmruntimes/semeru25-binaries/releases/download/jdk-25.0.4.0/ibm-semeru-open-jdk_aarch64_mac_25.0.4.0.pkg